### PR TITLE
Add access_token support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ the path specified by the name or path attribute.
 * `path` - path to the s3cfg file to render
 * `access_key` - AWS access key id
 * `secret_key` - AWS secret access key
+* `access_token` - AWS security token
 * `host_bucket` - Override the default bucket name. Should be the full
   FQDN, e.g., `mybucket.s3.amazonaws.com`.
 * `install_s3cmd` - Whether the `s3cmd` package should be installed.
@@ -47,8 +48,8 @@ the path specified by the name or path attribute.
 * `source` - passed to the `source` attribute of the template, default `s3cfg.erb`
 * `config` - Hash of configuration overrides that will be merged with
   the `node['s3cfg']['config']` attributes to dynamically render in
-  `s3cfg.erb`. Note that `access_key`, `secret_key` and `host_bucket`
-  are added to this.
+  `s3cfg.erb`. Note that `access_key`, `secret_key`, `access_token` and
+  `host_bucket` are added to this.
 
 ## Usage
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -50,6 +50,7 @@ end
 def config_options
   new_resource.config['access_key'] = new_resource.access_key
   new_resource.config['secret_key'] = new_resource.secret_key
+  new_resource.config['access_token'] = new_resource.access_token
   new_resource.config['host_bucket'] = new_resource.host_bucket
   node['s3cfg']['config'].to_hash.merge!(new_resource.config)
 end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -29,5 +29,6 @@ attribute :install_s3cmd, :kind_of => [FalseClass, TrueClass, NilClass], :defaul
 attribute :mode, :kind_of => [String, Fixnum], :default => 00600
 attribute :owner, :kind_of => String, :default => nil
 attribute :secret_key, :kind_of => String, :default => nil, :required => true
+attribute :access_token, :kind_of => String, :default => nil
 attribute :source, :kind_of => String, :default => "s3cfg.erb"
 attribute :variables, :kind_of => Hash, :default => {}


### PR DESCRIPTION
Hi Joshua!

This small PR adds [Amazon Security Token](http://docs.aws.amazon.com/STS/latest/UsingSTS/STSUseCases.html) support. This is used among others by the [IAM role credentials](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html).

Thanks for this great cookbook by the way :smile:
